### PR TITLE
Feat/issue-30

### DIFF
--- a/src/main/java/dev/memocode/memo_server/domain/memo/dto/request/MemoCreateDTO.java
+++ b/src/main/java/dev/memocode/memo_server/domain/memo/dto/request/MemoCreateDTO.java
@@ -1,5 +1,6 @@
 package dev.memocode.memo_server.domain.memo.dto.request;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -12,8 +13,11 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MemoCreateDTO {
+    @NotNull(message = "제목이 비어있습니다.")
     private String title;
+    @NotNull(message = "내용이 비어있습니다.")
     private String content;
+    @NotNull(message = "요약이 비어있습니다.")
     private String summary;
     private UUID authorId;
 }

--- a/src/main/java/dev/memocode/memo_server/domain/memo/dto/request/MemoCreateDTO.java
+++ b/src/main/java/dev/memocode/memo_server/domain/memo/dto/request/MemoCreateDTO.java
@@ -14,5 +14,6 @@ import java.util.UUID;
 public class MemoCreateDTO {
     private String title;
     private String content;
+    private String summary;
     private UUID authorId;
 }

--- a/src/main/java/dev/memocode/memo_server/domain/memo/dto/request/MemoUpdateDTO.java
+++ b/src/main/java/dev/memocode/memo_server/domain/memo/dto/request/MemoUpdateDTO.java
@@ -17,6 +17,7 @@ public class MemoUpdateDTO {
     private UUID authorId;
     private String title;
     private String content;
+    private String summary;
     private Boolean visibility;
     private Boolean security;
     private Boolean bookmarked;

--- a/src/main/java/dev/memocode/memo_server/domain/memo/dto/response/MemoDetailDTO.java
+++ b/src/main/java/dev/memocode/memo_server/domain/memo/dto/response/MemoDetailDTO.java
@@ -16,6 +16,7 @@ public class MemoDetailDTO {
     private UUID id;
     private String title;
     private String content;
+    private String summary;
     private Boolean visibility;
     private Boolean security;
     private Boolean bookmarked;

--- a/src/main/java/dev/memocode/memo_server/domain/memo/entity/Memo.java
+++ b/src/main/java/dev/memocode/memo_server/domain/memo/entity/Memo.java
@@ -89,10 +89,11 @@ public class Memo extends AggregateRoot {
     }
 
     // 메모 수정
-    public void updateMemo(String title, String content, Boolean visibility, Boolean security, Boolean bookmarked) {
+    public void updateMemo(String title, String content, String summary, Boolean visibility, Boolean security, Boolean bookmarked) {
 
         this.title = title == null ? this.title : title;
         this.content = content == null ? this.content : content;
+        this.summary = summary == null ? this.summary : summary;
         this.bookmarked = bookmarked == null ? this.bookmarked : bookmarked;
 
         if (security != null) {

--- a/src/main/java/dev/memocode/memo_server/domain/memo/entity/Memo.java
+++ b/src/main/java/dev/memocode/memo_server/domain/memo/entity/Memo.java
@@ -40,6 +40,9 @@ public class Memo extends AggregateRoot {
     @Column(name = "content")
     private String content;
 
+    @Column(name = "summary")
+    private String summary;
+
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "author_id")
     private Author author;

--- a/src/main/java/dev/memocode/memo_server/domain/memo/mapper/MemoMapper.java
+++ b/src/main/java/dev/memocode/memo_server/domain/memo/mapper/MemoMapper.java
@@ -16,6 +16,7 @@ public class MemoMapper {
                 .id(memo.getId())
                 .title(memo.getTitle())
                 .content(memo.getContent())
+                .summary(memo.getSummary())
                 .visibility(memo.getVisibility())
                 .security(memo.getSecurity())
                 .bookmarked(memo.getBookmarked())

--- a/src/main/java/dev/memocode/memo_server/domain/memo/service/MemoService.java
+++ b/src/main/java/dev/memocode/memo_server/domain/memo/service/MemoService.java
@@ -88,7 +88,7 @@ public class MemoService implements MemoUseCase {
 
         Memo memo = internalMemoService.findByMemoIdElseThrow(dto.getMemoId());
 
-        memo.updateMemo(dto.getTitle(), dto.getContent(), dto.getVisibility(), dto.getSecurity(), dto.getBookmarked());
+        memo.updateMemo(dto.getTitle(), dto.getContent(), dto.getSummary(), dto.getVisibility(), dto.getSecurity(), dto.getBookmarked());
     }
 
     @Override

--- a/src/main/java/dev/memocode/memo_server/domain/memo/service/MemoService.java
+++ b/src/main/java/dev/memocode/memo_server/domain/memo/service/MemoService.java
@@ -52,6 +52,7 @@ public class MemoService implements MemoUseCase {
         Memo memo = Memo.builder()
                 .title(dto.getTitle())
                 .content(dto.getContent())
+                .summary(dto.getSummary())
                 .author(author)
                 .affinity(0)
                 .sequence(lastSequence + DEFAULT_ADD_INDEX)

--- a/src/main/java/dev/memocode/memo_server/in/api/controller/MemoController.java
+++ b/src/main/java/dev/memocode/memo_server/in/api/controller/MemoController.java
@@ -71,6 +71,7 @@ public class MemoController implements MemoApi {
                 .authorId(UUID.fromString(jwt.getClaim(USER_ID_CLAIM_NAME)))
                 .title(form.getTitle())
                 .content(form.getContent())
+                .summary(form.getSummary())
                 .visibility(form.getVisibility())
                 .security(form.getSecurity())
                 .bookmarked(form.getBookmarked())

--- a/src/main/java/dev/memocode/memo_server/in/api/controller/MemoController.java
+++ b/src/main/java/dev/memocode/memo_server/in/api/controller/MemoController.java
@@ -37,6 +37,7 @@ public class MemoController implements MemoApi {
         MemoCreateDTO dto = MemoCreateDTO.builder()
                 .title(form.getTitle())
                 .content(form.getContent())
+                .summary(form.getSummary())
                 .authorId(UUID.fromString(jwt.getClaim(USER_ID_CLAIM_NAME)))
                 .build();
 

--- a/src/main/java/dev/memocode/memo_server/in/api/form/MemoCreateForm.java
+++ b/src/main/java/dev/memocode/memo_server/in/api/form/MemoCreateForm.java
@@ -15,7 +15,8 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 public class MemoCreateForm {
     @Schema(requiredMode = REQUIRED)
     private String title;
-
     @Schema(requiredMode = REQUIRED)
     private String content;
+    @Schema(requiredMode = REQUIRED)
+    private String summary;
 }

--- a/src/main/java/dev/memocode/memo_server/in/api/form/MemoUpdateForm.java
+++ b/src/main/java/dev/memocode/memo_server/in/api/form/MemoUpdateForm.java
@@ -10,9 +10,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class MemoUpdateForm {
-    // createForm 겹치는 문제
     private String title;
     private String content;
+    private String summary;
     private Boolean visibility;
     private Boolean security;
     private Boolean bookmarked;

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -31,7 +31,7 @@ CREATE TABLE memos
     id                     CHAR(36) PRIMARY KEY,
     title                  VARCHAR(255),
     content                LONGTEXT,
-    summary                LONGTEXT,
+    summary                TEXT,
     author_id              CHAR(36),
     series_id              CHAR(36),
     affinity               INT,

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -31,6 +31,7 @@ CREATE TABLE memos
     id                     CHAR(36) PRIMARY KEY,
     title                  VARCHAR(255),
     content                LONGTEXT,
+    summary                LONGTEXT,
     author_id              CHAR(36),
     series_id              CHAR(36),
     affinity               INT,

--- a/src/test/java/dev/memocode/memo_server/usecase/CommentUseCaseTest.java
+++ b/src/test/java/dev/memocode/memo_server/usecase/CommentUseCaseTest.java
@@ -69,6 +69,7 @@ class CommentUseCaseTest {
                 .authorId(authorId)
                 .title("테스트 제목입니다.")
                 .content("테스트 내용입니다.")
+                .summary("요약 내용입니다.")
                 .build();
 
         UUID memoId = memoUseCase.createMemo(dto);

--- a/src/test/java/dev/memocode/memo_server/usecase/PostUseCaseTest.java
+++ b/src/test/java/dev/memocode/memo_server/usecase/PostUseCaseTest.java
@@ -4,11 +4,9 @@ import dev.memocode.memo_server.domain.author.entity.Author;
 import dev.memocode.memo_server.domain.author.repository.AuthorRepository;
 import dev.memocode.memo_server.domain.memo.dto.request.MemoCreateDTO;
 import dev.memocode.memo_server.domain.memo.dto.request.MemoUpdateDTO;
+import dev.memocode.memo_server.domain.memo.dto.response.MemosDTO;
 import dev.memocode.memo_server.domain.memo.dto.response.PostAuthorDTO;
-import dev.memocode.memo_server.domain.memo.repository.MemoRepository;
-import dev.memocode.memo_server.domain.memo.service.MemoService;
-import dev.memocode.memo_server.domain.memo.service.PostService;
-import org.junit.jupiter.api.AfterEach;
+import jakarta.validation.ConstraintViolationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,6 +20,7 @@ import java.time.Instant;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -55,6 +54,44 @@ class PostUseCaseTest {
                 .deletedAt(null)
                 .build();
         return authorRepository.save(author);
+    }
+
+    @Test
+    @DisplayName("메모 생성 성공")
+    void createMemo_success(){
+        MemoCreateDTO dto1 = MemoCreateDTO.builder()
+                .authorId(savedAuthor.getId())
+                .title("테스트 제목입니다.")
+                .content("테스트 내용입니다.")
+                .summary("요약 내용입니다.")
+                .build();
+
+        memoUseCase.createMemo(dto1);
+
+        MemoCreateDTO dto2 = MemoCreateDTO.builder()
+                .authorId(savedAuthor.getId())
+                .title("테스트 제목입니다.")
+                .content("테스트 내용입니다.")
+                .summary("요약 내용입니다.")
+                .build();
+
+        memoUseCase.createMemo(dto2);
+        MemosDTO memos = memoUseCase.findMemos(savedAuthor.getId());
+        assertThat(memos.getData().size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("메모 제목이 null 값이라 ConstraintViolationException 예외 발생")
+    void createMemoNotTitle_fail(){
+        MemoCreateDTO dto = MemoCreateDTO.builder()
+                .authorId(savedAuthor.getId())
+                .content("테스트 내용입니다.")
+                .summary("요약 내용입니다.")
+                .build();
+
+        assertThrows(ConstraintViolationException.class, () -> {
+            memoUseCase.createMemo(dto);
+        });
     }
 
     @Test

--- a/src/test/java/dev/memocode/memo_server/usecase/PostUseCaseTest.java
+++ b/src/test/java/dev/memocode/memo_server/usecase/PostUseCaseTest.java
@@ -22,6 +22,7 @@ import java.time.Instant;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
@@ -91,11 +92,9 @@ class PostUseCaseTest {
                 .summary("요약 내용입니다.")
                 .build();
 
-        ConstraintViolationException exception = assertThrows(ConstraintViolationException.class, () -> {
-            memoUseCase.createMemo(dto);
-        });
-
-        assertTrue(exception.getMessage().contains("제목이 비어있습니다."));
+        assertThatThrownBy(() -> memoUseCase.createMemo(dto))
+                .isInstanceOf(ConstraintViolationException.class)
+                .hasMessageContaining("제목이 비어있습니다.");
     }
 
     @Test
@@ -155,11 +154,9 @@ class PostUseCaseTest {
                 .bookmarked(false)
                 .build();
 
-        GlobalException exception = assertThrows(GlobalException.class, () -> {
-            memoUseCase.updateMemo(updateDTO);
-        });
-
-        assertTrue(exception.getMessage().contains("메모에 접근할 권한이 없습니다."));
+        assertThatThrownBy(() -> memoUseCase.updateMemo(updateDTO))
+                .isInstanceOf(GlobalException.class)
+                .hasMessageContaining("메모에 접근할 권한이 없습니다.");
     }
 
     @Test

--- a/src/test/java/dev/memocode/memo_server/usecase/PostUseCaseTest.java
+++ b/src/test/java/dev/memocode/memo_server/usecase/PostUseCaseTest.java
@@ -64,6 +64,7 @@ class PostUseCaseTest {
                 .authorId(savedAuthor.getId())
                 .title("테스트 제목입니다.")
                 .content("테스트 내용입니다.")
+                .summary("요약 내용입니다.")
                 .build();
 
         UUID memoId = memoUseCase.createMemo(dto);
@@ -88,6 +89,7 @@ class PostUseCaseTest {
                 .authorId(savedAuthor.getId())
                 .title("테스트 제목입니다.")
                 .content("테스트 내용입니다.")
+                .summary("요약 내용입니다.")
                 .build();
 
         UUID memoId1 = memoUseCase.createMemo(dto1);
@@ -96,6 +98,7 @@ class PostUseCaseTest {
                 .authorId(savedAuthor.getId())
                 .title("테스트 제목입니다.")
                 .content("테스트 내용입니다.")
+                .summary("요약 내용입니다.")
                 .build();
 
         memoUseCase.createMemo(dto2);

--- a/src/test/java/dev/memocode/memo_server/usecase/PostUseCaseTest.java
+++ b/src/test/java/dev/memocode/memo_server/usecase/PostUseCaseTest.java
@@ -22,8 +22,7 @@ import java.time.Instant;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -92,9 +91,11 @@ class PostUseCaseTest {
                 .summary("요약 내용입니다.")
                 .build();
 
-        assertThrows(ConstraintViolationException.class, () -> {
+        ConstraintViolationException exception = assertThrows(ConstraintViolationException.class, () -> {
             memoUseCase.createMemo(dto);
         });
+
+        assertTrue(exception.getMessage().contains("제목이 비어있습니다."));
     }
 
     @Test
@@ -154,10 +155,11 @@ class PostUseCaseTest {
                 .bookmarked(false)
                 .build();
 
-        assertThrows(GlobalException.class, () -> {
+        GlobalException exception = assertThrows(GlobalException.class, () -> {
             memoUseCase.updateMemo(updateDTO);
         });
 
+        assertTrue(exception.getMessage().contains("메모에 접근할 권한이 없습니다."));
     }
 
     @Test


### PR DESCRIPTION
### ✨ 작업 내용
---

- [x] memo 생성 시 summary 추가
- [x] memo summary 수정
- [x] 메모 생성 테스트
- [x] 메모 수정 테스트

### ✨ 참고 사항
---

메모 작성 시 처음에 summary를 작성할 수 있도록 수정하였습니다.

```java
public class MemoCreateForm {
    @Schema(requiredMode = REQUIRED)
    private String title;
    @Schema(requiredMode = REQUIRED)
    private String content;
    @Schema(requiredMode = REQUIRED)
    private String summary;
}
```

이 부분에서 `@Schema(requiredMode = REQUIRED)` 있어도 null 값이 들어가는 문제가 있었습니다.
모든 부분에서 valid를 적용한 것은 아니지만 테스트 코드 작성을 위하여

```java
public class MemoCreateDTO {
    @NotNull(message = "제목이 비어있습니다.")
    private String title;
    @NotNull(message = "내용이 비어있습니다.")
    private String content;
    @NotNull(message = "요약이 비어있습니다.")
    private String summary;
    private UUID authorId;
}
```

```java
@Validated
public interface MemoUseCase {

    UUID createMemo(@Valid MemoCreateDTO dto);
}
```

`@NotNull` 추가해주었습니다. (메모 작성시 제목, 내용, 소개글은 null이 들어갈 수 없다고 가정하였습니다.)


### ⏰ 현재 버그
---

### ✏ Git Close
---

close #30 