### PR TITLE
Feat/issue-33

### DIFF
--- a/src/main/java/dev/memocode/memo_server/domain/memo/dto/response/PostAuthorDTO.java
+++ b/src/main/java/dev/memocode/memo_server/domain/memo/dto/response/PostAuthorDTO.java
@@ -18,6 +18,7 @@ public class PostAuthorDTO {
     private UUID id;
     private String title;
     private String content;
+    private Integer commentCounts;
     private Instant cratedAt;
     private Instant updatedAt;
     private AuthorDTO author;
@@ -27,6 +28,7 @@ public class PostAuthorDTO {
                 .id(post.getId())
                 .title(post.getTitle())
                 .content(post.getContent())
+                .commentCounts(post.getComments().size())
                 .cratedAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
                 .author(AuthorDTO.builder()

--- a/src/main/java/dev/memocode/memo_server/domain/memo/dto/response/PostDetailDTO.java
+++ b/src/main/java/dev/memocode/memo_server/domain/memo/dto/response/PostDetailDTO.java
@@ -18,6 +18,7 @@ public class PostDetailDTO {
     private UUID id;
     private String title;
     private String content;
+    private Integer commentCounts;
     private Instant createdAt;
     private AuthorDTO author;
 }

--- a/src/main/java/dev/memocode/memo_server/domain/memo/dto/response/PostsDTO.java
+++ b/src/main/java/dev/memocode/memo_server/domain/memo/dto/response/PostsDTO.java
@@ -18,6 +18,7 @@ public class PostsDTO {
     private UUID id;
     private String title;
     private String content;
+    private Integer commentCounts;
     private Instant createdAt;
     private AuthorDTO author;
 }

--- a/src/main/java/dev/memocode/memo_server/domain/memo/entity/Memo.java
+++ b/src/main/java/dev/memocode/memo_server/domain/memo/entity/Memo.java
@@ -11,6 +11,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.LazyCollection;
+import org.hibernate.annotations.LazyCollectionOption;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
@@ -79,6 +81,7 @@ public class Memo extends AggregateRoot {
 
     // 게시글 댓글 수 가져오기
     @OneToMany(mappedBy = "memo")
+    @LazyCollection(LazyCollectionOption.EXTRA) // comment count query
     @Builder.Default
     private List<Comment> comments = new ArrayList<>();
 

--- a/src/main/java/dev/memocode/memo_server/domain/memo/mapper/PostMapper.java
+++ b/src/main/java/dev/memocode/memo_server/domain/memo/mapper/PostMapper.java
@@ -34,6 +34,7 @@ public class PostMapper {
                 .id(post.getId())
                 .title(post.getTitle())
                 .content(post.getContent())
+                .commentCounts(post.getComments().size())
                 .createdAt(post.getCreatedAt())
                 .author(AuthorDTO.builder()
                         .authorId(post.getAuthor().getId())

--- a/src/main/java/dev/memocode/memo_server/domain/memo/mapper/PostMapper.java
+++ b/src/main/java/dev/memocode/memo_server/domain/memo/mapper/PostMapper.java
@@ -19,6 +19,7 @@ public class PostMapper {
                 .id(memo.getId())
                 .title(memo.getTitle())
                 .content(memo.getContent())
+                .commentCounts(memo.getComments().size())
                 .createdAt(memo.getCreatedAt())
                 .author(AuthorDTO.builder()
                         .authorId(memo.getAuthor().getId())

--- a/src/main/java/dev/memocode/memo_server/domain/memo/service/InternalMemoService.java
+++ b/src/main/java/dev/memocode/memo_server/domain/memo/service/InternalMemoService.java
@@ -9,8 +9,7 @@ import org.springframework.stereotype.Service;
 import java.util.Optional;
 import java.util.UUID;
 
-import static dev.memocode.memo_server.domain.base.exception.GlobalErrorCode.MEMO_NOT_FOUND;
-import static dev.memocode.memo_server.domain.base.exception.GlobalErrorCode.NOT_VALID_MEMO_OWNER;
+import static dev.memocode.memo_server.domain.base.exception.GlobalErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +23,18 @@ public class InternalMemoService {
 
         if (!memo.getAuthor().getId().equals(authorId)){
             throw new GlobalException(NOT_VALID_MEMO_OWNER);
+        }
+    }
+
+    void validPost(UUID memoId) {
+        Memo memo = findByMemoIdElseThrow(memoId);
+
+        if (memo.getDeleted()){
+            throw new GlobalException(MEMO_NOT_FOUND);
+        }
+
+        if (!memo.getVisibility()){
+            throw new GlobalException(POST_NOT_FOUND);
         }
     }
 

--- a/src/main/java/dev/memocode/memo_server/domain/memo/service/PostService.java
+++ b/src/main/java/dev/memocode/memo_server/domain/memo/service/PostService.java
@@ -36,21 +36,10 @@ public class PostService implements PostUseCase {
 
     @Override
     public PostDetailDTO findPost(UUID memoId) {
+        internalMemoService.validPost(memoId);
         Memo memo = internalMemoService.findByMemoIdElseThrow(memoId);
 
-        validPost(memo);
-
         return postMapper.entity_to_postDetailDTO(memo);
-    }
-
-    private static void validPost(Memo memo) {
-        if (memo.getDeleted()){
-            throw new GlobalException(MEMO_NOT_FOUND);
-        }
-
-        if (!memo.getVisibility()){
-            throw new GlobalException(POST_NOT_FOUND);
-        }
     }
 
     @Override


### PR DESCRIPTION
### ✨ 작업 내용
---

- [x] 단일 게시글에 comment count 추가
- [x] 전체 게시글 comment count 추가
- [x] 해당 사용자의 블로그 게시글 comment count 추가

### ✨ 참고 사항
---

```java
    @OneToMany(mappedBy = "memo")
    @LazyCollection(LazyCollectionOption.EXTRA) // comment count query
    @Builder.Default
    private List<Comment> comments = new ArrayList<>();
```

```sql
    select
        count(id)      
    from
        comments      
    where
        memo_id='48814b08-4167-4846-9be3-d838ad619484'          
        and (
            is_deleted = false         
        ) 
```

`@LazyCollection(LazyCollectionOption.EXTRA)` memo에서 comment count를 나오게 해주는 어노테이션 입니다.

### ⏰ 현재 버그
---

현재 게시글 전체 조회할 경우 count query가 게시글의 갯수만큼 나갑니다.
추후 최적화를 통하여 수정할 예정입니다.

### ✏ Git Close
---

close #33 