### PR TITLE
Type com.meilisearch.sdk.Index is instantiated reflectively but was n…

### DIFF
--- a/src/main/java/dev/memocode/memo_server/domain/base/config/MeilisearchRuntimeHintsRegistrar.java
+++ b/src/main/java/dev/memocode/memo_server/domain/base/config/MeilisearchRuntimeHintsRegistrar.java
@@ -20,5 +20,11 @@ public class MeilisearchRuntimeHintsRegistrar implements RuntimeHintsRegistrar {
             hint.withMembers(MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS);
             hint.withMembers(MemberCategory.PUBLIC_FIELDS);
         });
+
+        hints.reflection().registerType(TypeReference.of("com.meilisearch.sdk.exceptions.MeilisearchApiException"), hint -> {
+            hint.withMembers(MemberCategory.INVOKE_PUBLIC_METHODS);
+            hint.withMembers(MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS);
+            hint.withMembers(MemberCategory.PUBLIC_FIELDS);
+        });
     }
 }


### PR DESCRIPTION
…ever registered. Register the type by adding unsafeAllocated for the type in reflect-config.json 해결중3