### PR TITLE
Type com.meilisearch.sdk.Index is instantiated reflectively but was n…

### DIFF
--- a/src/main/java/dev/memocode/memo_server/domain/base/config/MeiliSearchConfig.java
+++ b/src/main/java/dev/memocode/memo_server/domain/base/config/MeiliSearchConfig.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportRuntimeHints;
 
 @Configuration
-@ImportRuntimeHints({MeilisearchRuntimeHintsRegistrar.class})
+//@ImportRuntimeHints({MeilisearchRuntimeHintsRegistrar.class})
 public class MeiliSearchConfig {
 
     @Value("${custom.meilisearch.api-key}")

--- a/src/main/java/dev/memocode/memo_server/domain/base/config/MeilisearchRuntimeHintsRegistrar.java
+++ b/src/main/java/dev/memocode/memo_server/domain/base/config/MeilisearchRuntimeHintsRegistrar.java
@@ -20,11 +20,5 @@ public class MeilisearchRuntimeHintsRegistrar implements RuntimeHintsRegistrar {
             hint.withMembers(MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS);
             hint.withMembers(MemberCategory.PUBLIC_FIELDS);
         });
-
-        hints.reflection().registerType(TypeReference.of("com.meilisearch.sdk.exceptions.MeilisearchApiException"), hint -> {
-            hint.withMembers(MemberCategory.INVOKE_PUBLIC_METHODS);
-            hint.withMembers(MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS);
-            hint.withMembers(MemberCategory.PUBLIC_FIELDS);
-        });
     }
 }


### PR DESCRIPTION
…ever registered. Register the type by adding unsafeAllocated for the type in reflect-config.json 해결중4